### PR TITLE
Enable the LPR backend for GTK 3.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+debathena-printing-config (1.34) unstable; urgency=low
+
+  * Transform /etc/gtk-3.0/settings.ini to enable the LPR backend
+    (Trac: #1485)
+  * Bump Standards-Version to 3.9.3
+
+ -- Jonathan Reed <jdreed@mit.edu>  Thu, 12 Jun 2014 10:37:22 -0400
+
 debathena-printing-config (1.33) unstable; urgency=low
 
   * Add git-buildpackage configuration

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: debathena-printing-config
 Section: debathena-config/net
 Priority: extra
 Maintainer: Debathena Project <debathena@mit.edu>
-Build-Depends: cdbs (>= 0.4.43), debhelper (>= 5.0.37.2), config-package-dev (>= 4.12~), python-all (>= 2.3.5-11), python-support (>= 0.3.2), gettext, python-setuptools, python-nose, python-hesiod, python-cups, python-debian, python-apt, cups
-Standards-Version: 3.9.0
+Build-Depends: cdbs (>= 0.4.43), debhelper (>= 5.0.37.2), config-package-dev (>= 4.12~), python-all (>= 2.3.5-11), python-support (>= 0.3.2), gettext, python-setuptools, python-nose, python-hesiod, python-cups, python-debian, python-apt, cups, libgtk-3-0
+Standards-Version: 3.9.3
 
 Package: debathena-printing-config
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@ DEB_PYTHON_SYSTEM = pysupport
 
 DEB_DIVERT_EXTENSION = .debathena
 
+DEB_TRANFORM_FILES_debathena-printing-config += \
+	/etc/gtk-3.0/settings.ini.debathena
+
 DEB_DIVERT_FILES_debathena-printing-config += \
 	/usr/bin/lp.debathena \
 	/usr/bin/lpq.debathena \

--- a/debian/transform_settings.init.debathena
+++ b/debian/transform_settings.init.debathena
@@ -1,0 +1,6 @@
+#!/usr/bin/perl -p0
+if (m/^gtk-print-backends/m) {
+	s/^gtk-print-backends.*$/gtk-print-backends = file,cups,lpr/m;
+} else {
+	s/$/\ngtk-print-backends = file,cups,lpr/;
+}


### PR DESCRIPTION
- Transform /etc/gtk-3.0/settings.ini to enable the LPR backend
  per (Trac: #1485)
- Bump Standards-Version to 3.9.3
